### PR TITLE
Removing yarn - it isn't supported

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      
-  - package-ecosystem: "yarn"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Didn't notice this when originally adding dependabot!